### PR TITLE
Feature/batch accounts query

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,4 +4,5 @@ module.exports = {
   singleQuote: true,
   printWidth: 120,
   tabWidth: 2,
-}
+  bracketSpacing: false,
+};

--- a/src/GraphClient.ts
+++ b/src/GraphClient.ts
@@ -28,8 +28,8 @@ export default class GraphClient {
     });
   }
 
-  public async queryOrThrow<T>(query: DocumentNode) {
-    const result = await this.apollo.query<T>({query, fetchPolicy: 'network-only'});
+  public async queryOrThrow<T>(query: DocumentNode, variables?: Object) {
+    const result = await this.apollo.query<T>({query, fetchPolicy: 'network-only', variables});
     if (result.error) {
       throw new Error(result.error.message);
     }

--- a/src/GraphClient.ts
+++ b/src/GraphClient.ts
@@ -1,6 +1,13 @@
 // prettier-ignore
 import {
-  ApolloClient, NormalizedCacheObject, InMemoryCache, HttpLink, from, DocumentNode,
+  ApolloClient,
+  NormalizedCacheObject,
+  InMemoryCache,
+  HttpLink,
+  from,
+  DocumentNode,
+  OperationVariables,
+  TypedDocumentNode,
 } from '@apollo/client/core';
 import {onError} from '@apollo/client/link/error';
 import {RetryLink} from '@apollo/client/link/retry';
@@ -28,8 +35,11 @@ export default class GraphClient {
     });
   }
 
-  public async queryOrThrow<T>(query: DocumentNode, variables?: Object) {
-    const result = await this.apollo.query<T>({query, fetchPolicy: 'network-only', variables});
+  public async queryOrThrow<TData = any, TVariables = OperationVariables>(
+    query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+    variables?: TVariables,
+  ) {
+    const result = await this.apollo.query<TData, TVariables>({query, fetchPolicy: 'network-only', variables});
     if (result.error) {
       throw new Error(result.error.message);
     }

--- a/src/Notional.ts
+++ b/src/Notional.ts
@@ -4,7 +4,7 @@ import {
 import {System} from './system';
 import Governance from './Governance';
 import GraphClient from './GraphClient';
-import {Account} from './account';
+import {Account, AccountsBatch} from './account';
 
 /* typechain imports */
 import {NoteERC20} from './typechain/NoteERC20';
@@ -64,7 +64,7 @@ export default class Notional extends TransactionBuilder {
     chainId: number,
     provider: ethers.providers.Provider,
     refreshDataInterval = CACHE_DATA_REFRESH_INTERVAL,
-    dataSourceType = DataSourceType.Cache
+    dataSourceType = DataSourceType.Cache,
   ) {
     let addresses: any;
     let graphEndpoint: string;
@@ -110,7 +110,7 @@ export default class Notional extends TransactionBuilder {
       chainId,
       dataSourceType,
       refreshDataInterval,
-      DEFAULT_CONFIGURATION_REFRESH_INTERVAL
+      DEFAULT_CONFIGURATION_REFRESH_INTERVAL,
     );
 
     // await for the first data refresh before returning
@@ -133,6 +133,10 @@ export default class Notional extends TransactionBuilder {
     );
   }
 
+  public async getAccounts(pageSize: number, pageNumber: number) {
+    return await AccountsBatch.load(this.graphClient, pageSize, pageNumber);
+  }
+
   public parseInput(input: string, symbol: string, isInternal: boolean) {
     const bnType = TypedBigNumber.getType(symbol, isInternal);
     const currency = this.system.getCurrencyBySymbol(symbol);
@@ -147,7 +151,7 @@ export default class Notional extends TransactionBuilder {
     }
 
     try {
-      const value = utils.parseUnits(input.replace(',',''), decimalPlaces);
+      const value = utils.parseUnits(input.replace(',', ''), decimalPlaces);
       return TypedBigNumber.from(BigNumber.from(value), bnType, symbol);
     } catch {
       return undefined;
@@ -156,9 +160,9 @@ export default class Notional extends TransactionBuilder {
 
   public isNotionalContract(counterparty: string) {
     return (
-      (counterparty == this.system.getNotionalProxy().address) ||
-      (counterparty == this.governance.getContract().address) ||
-      (counterparty == this.note.address)
+      counterparty == this.system.getNotionalProxy().address ||
+      counterparty == this.governance.getContract().address ||
+      counterparty == this.note.address
     );
   }
 }

--- a/src/account/AccountData.ts
+++ b/src/account/AccountData.ts
@@ -106,9 +106,10 @@ export default class AccountData {
       const underlyingSymbol = system.getUnderlyingSymbol(v.currencyId.toNumber());
       const maturity = v.maturity.toNumber();
       const assetType = convertAssetType(v.assetType);
-      const notional = assetType === AssetType.fCash
-        ? TypedBigNumber.from(v.notional, BigNumberType.InternalUnderlying, underlyingSymbol)
-        : TypedBigNumber.from(v.notional, BigNumberType.LiquidityToken, currency.symbol);
+      const notional =
+        assetType === AssetType.fCash
+          ? TypedBigNumber.from(v.notional, BigNumberType.InternalUnderlying, underlyingSymbol)
+          : TypedBigNumber.from(v.notional, BigNumberType.LiquidityToken, currency.symbol);
       const settlementDate = CashGroup.getSettlementDate(assetType, maturity);
 
       return {
@@ -234,12 +235,8 @@ export default class AccountData {
 
     /* eslint-disable @typescript-eslint/no-shadow */
     /* eslint-disable no-param-reassign */
-    const {
-      cashDebts, cashAssets, cashDebtsWithBuffer, cashAssetsWithHaircut, cashGroups,
-    } = this.accountBalances.reduce(
-      ({
-        cashDebts, cashAssets, cashDebtsWithBuffer, cashAssetsWithHaircut, cashGroups,
-      }, b) => {
+    const {cashDebts, cashAssets, cashDebtsWithBuffer, cashAssetsWithHaircut, cashGroups} = this.accountBalances.reduce(
+      ({cashDebts, cashAssets, cashDebtsWithBuffer, cashAssetsWithHaircut, cashGroups}, b) => {
         if (b.cashBalance.isNegative()) {
           cashDebts = cashDebts.add(b.cashBalance.toETH(false).abs());
           cashDebtsWithBuffer = cashDebtsWithBuffer.add(b.cashBalance.toETH(true).abs());
@@ -259,7 +256,8 @@ export default class AccountData {
           undefined,
           false,
         );
-        const {totalCashClaims: totalCashClaimsHaircut, fCashAssets: fCashAssetsHaircut} = FreeCollateral.getNetfCashPositions(b.currencyId, this.portfolio, undefined, true);
+        const {totalCashClaims: totalCashClaimsHaircut, fCashAssets: fCashAssetsHaircut} =
+          FreeCollateral.getNetfCashPositions(b.currencyId, this.portfolio, undefined, true);
 
         cashAssets = cashAssets.add(totalCashClaims.toETH(false));
         cashAssetsWithHaircut = cashAssetsWithHaircut.add(totalCashClaimsHaircut.toETH(true));
@@ -284,15 +282,8 @@ export default class AccountData {
       },
     );
 
-    const {
-      fCashDebts, fCashAssets, fCashAssetsWithHaircut, fCashDebtsWithBuffer,
-    } = cashGroups.reduce(
-      (
-        {
-          fCashDebts, fCashAssets, fCashAssetsWithHaircut, fCashDebtsWithBuffer,
-        },
-        {currencyId, haircut, noHaircut},
-      ) => {
+    const {fCashDebts, fCashAssets, fCashAssetsWithHaircut, fCashDebtsWithBuffer} = cashGroups.reduce(
+      ({fCashDebts, fCashAssets, fCashAssetsWithHaircut, fCashDebtsWithBuffer}, {currencyId, haircut, noHaircut}) => {
         const cashGroup = system.getCashGroup(currencyId);
 
         noHaircut.forEach((a) => {
@@ -338,10 +329,12 @@ export default class AccountData {
     let haircutLoanToValue: number | null = null;
     let maxLoanToValue: number | null = null;
     if (!totalETHValue.isZero()) {
-      loanToValue = (totalETHDebts.scale(INTERNAL_TOKEN_PRECISION, totalETHValue.n).toNumber() / INTERNAL_TOKEN_PRECISION) * 100;
-      haircutLoanToValue = (totalETHDebtsBuffer.scale(INTERNAL_TOKEN_PRECISION, totalETHValueHaircut.n).toNumber()
-          / INTERNAL_TOKEN_PRECISION)
-        * 100;
+      loanToValue =
+        (totalETHDebts.scale(INTERNAL_TOKEN_PRECISION, totalETHValue.n).toNumber() / INTERNAL_TOKEN_PRECISION) * 100;
+      haircutLoanToValue =
+        (totalETHDebtsBuffer.scale(INTERNAL_TOKEN_PRECISION, totalETHValueHaircut.n).toNumber() /
+          INTERNAL_TOKEN_PRECISION) *
+        100;
       maxLoanToValue = (loanToValue / haircutLoanToValue) * 100;
     }
 
@@ -358,7 +351,8 @@ export default class AccountData {
     // We represent everything as FX to ETH so in the case that the collateral is in ETH we
     // vary the debt currency id
     const targetId = collateralId === ETHER_CURRENCY_ID ? debtCurrencyId : collateralId;
-    const {netETHCollateralWithHaircut, netETHDebtWithBuffer, netUnderlyingAvailable} = FreeCollateral.getFreeCollateral(this);
+    const {netETHCollateralWithHaircut, netETHDebtWithBuffer, netUnderlyingAvailable} =
+      FreeCollateral.getFreeCollateral(this);
     const aggregateFC = netETHCollateralWithHaircut.sub(netETHDebtWithBuffer);
     const targetCurrencyFC = aggregateFC.fromETH(targetId, true);
     const netUnderlying = netUnderlyingAvailable.get(targetId);
@@ -367,19 +361,20 @@ export default class AccountData {
     const fcSurplusProportion = targetCurrencyFC.scale(INTERNAL_TOKEN_PRECISION, netUnderlying.n).abs();
     // This is the max exchange rate decrease as a portion of a single token in internal token precision, can
     // see this as the liquidation price of a single unit of ETH
-    const maxExchangeRateDecrease = collateralId === targetId
-      ? fcSurplusProportion.copy(INTERNAL_TOKEN_PRECISION).sub(fcSurplusProportion)
-      : fcSurplusProportion.copy(INTERNAL_TOKEN_PRECISION).add(fcSurplusProportion);
+    const maxExchangeRateDecrease =
+      collateralId === targetId
+        ? fcSurplusProportion.copy(INTERNAL_TOKEN_PRECISION).sub(fcSurplusProportion)
+        : fcSurplusProportion.copy(INTERNAL_TOKEN_PRECISION).add(fcSurplusProportion);
 
     // Convert to the debt currency denomination
     return collateralId === ETHER_CURRENCY_ID
       ? // If using the debt currency this will do 1 / maxExchangeRateDecrease.toETH(), returning a TypedNumber
-    // in the debt currency denomination
-      maxExchangeRateDecrease
-        .copy(INTERNAL_TOKEN_PRECISION)
-        .scale(INTERNAL_TOKEN_PRECISION, maxExchangeRateDecrease.toETH(false).n)
+        // in the debt currency denomination
+        maxExchangeRateDecrease
+          .copy(INTERNAL_TOKEN_PRECISION)
+          .scale(INTERNAL_TOKEN_PRECISION, maxExchangeRateDecrease.toETH(false).n)
       : // Convert from collateral to debt via ETH
-      maxExchangeRateDecrease.toETH(false).fromETH(debtCurrencyId, false);
+        maxExchangeRateDecrease.toETH(false).fromETH(debtCurrencyId, false);
   }
 
   /**
@@ -453,9 +448,10 @@ export default class AccountData {
 
       // Sorting is done in place
       portfolio.sort(
-        (a, b) => a.currencyId - b.currencyId
-          || assetTypeNum(a.assetType) - assetTypeNum(b.assetType)
-          || a.maturity - b.maturity,
+        (a, b) =>
+          a.currencyId - b.currencyId ||
+          assetTypeNum(a.assetType) - assetTypeNum(b.assetType) ||
+          a.maturity - b.maturity,
       );
     }
 

--- a/src/account/AccountsBatch.ts
+++ b/src/account/AccountsBatch.ts
@@ -1,0 +1,165 @@
+// prettier-ignore
+import {
+  BigNumber,
+} from 'ethers';
+import {gql} from '@apollo/client/core';
+
+import {CashGroup, System} from '../system';
+import GraphClient from '../GraphClient';
+import TypedBigNumber from '../libs/TypedBigNumber';
+import {getNowSeconds} from '../libs/utils';
+import AccountData from './AccountData';
+import {AssetType} from '../libs/types';
+
+const accountsQuery = gql`
+  query getAccounts($pageSize: Int!, $pageNumber: Int!) {
+    accounts(first: $pageSize, skip: $pageNumber) {
+      id
+      nextSettleTime
+      hasCashDebt
+      hasPortfolioAssetDebt
+      assetBitmapCurrency {
+        id
+      }
+      balances {
+        currency {
+          id
+          symbol
+        }
+        assetCashBalance
+        nTokenBalance
+        lastClaimTime
+        lastClaimIntegralSupply
+      }
+      portfolio {
+        currency {
+          id
+          symbol
+        }
+        settlementDate
+        maturity
+        assetType
+        notional
+      }
+    }
+  }
+`;
+
+interface AssetResponse {
+  currency: {
+    id: string;
+    symbol: string;
+  };
+  settlementDate: string;
+  maturity: number;
+  assetType: string;
+  notional: number;
+}
+
+interface BalanceResponse {
+  currency: {
+    id: string;
+    symbol: string;
+  };
+  assetCashBalance: string;
+  nTokenBalance: string;
+  lastClaimTime: number;
+  lastClaimIntegralSupply: string;
+}
+
+interface AccountsQueryResponse {
+  accounts: {
+    id: string;
+    nextSettleTime: number;
+    hasCashDebt: boolean;
+    hasPortfolioAssetDebt: boolean;
+    assetBitmapCurrency: {
+      id: string;
+    } | null;
+    balances: BalanceResponse[];
+    portfolio: AssetResponse[];
+  }[];
+}
+
+export default class AccountsBatch {
+  public static parseBalance(balance: BalanceResponse) {
+    const currencyId = Number(balance.currency.id);
+    const currency = System.getSystem().getCurrencyById(currencyId);
+
+    if (!currency) {
+      throw Error(`Currency ${currencyId} cannot be found.`);
+    }
+
+    if (!currency.nTokenSymbol) {
+      throw Error(`Currency ${currencyId} does not have a nToken.`);
+    }
+
+    const cashBalance = TypedBigNumber.fromBalance(balance.assetCashBalance, currency.symbol, true);
+    const nTokenBalance = TypedBigNumber.fromBalance(balance.nTokenBalance, currency.nTokenSymbol, false);
+    const lastClaimTime = BigNumber.from(balance.lastClaimTime);
+    const lastClaimIntegralSupply = BigNumber.from(balance.lastClaimIntegralSupply);
+
+    return {
+      currencyId,
+      cashBalance,
+      nTokenBalance,
+      lastClaimTime,
+      lastClaimIntegralSupply,
+    };
+  }
+
+  static parseAsset(asset: AssetResponse) {
+    const currencyId = Number(asset.currency.id);
+    const {maturity} = asset;
+    const assetType = asset.assetType as AssetType;
+    const symbol = System.getSystem().getCurrencyById(currencyId)?.symbol;
+
+    if (!symbol) {
+      throw Error(`Currency ${currencyId} cannot be found.`);
+    }
+
+    const notional = TypedBigNumber.fromBalance(asset.notional, symbol, false);
+    const hasMatured = maturity < getNowSeconds();
+    const settlementDate = Number(asset.settlementDate);
+    const isIdiosyncratic = CashGroup.isIdiosyncratic(maturity);
+    return {
+      currencyId,
+      maturity,
+      assetType,
+      notional,
+      hasMatured,
+      settlementDate,
+      isIdiosyncratic,
+    };
+  }
+
+  /**
+   * Loads an account object
+   *
+   * @param signer
+   * @param provider
+   * @param system
+   * @returns
+   */
+  public static async load(graphClient: GraphClient, pageSize: number, pageNumber: number) {
+    const response = await graphClient.queryOrThrow<AccountsQueryResponse>(accountsQuery, {
+      variables: {pageSize, pageNumber},
+    });
+    const accounts = new Map<string, AccountData>();
+    response.accounts.forEach(async (account) => {
+      // Ideally, all settlement rates and markets that may be concerned by these accounts would be pre-loaded
+      // and these Promises could be avoided. Optimization will be needed once there are many settled markets.
+      // eslint-disable-next-line no-await-in-loop
+      const accountData = await AccountData.load(
+        account.nextSettleTime,
+        account.hasCashDebt,
+        account.hasPortfolioAssetDebt,
+        Number(account.assetBitmapCurrency?.id),
+        account.balances.map(AccountsBatch.parseBalance),
+        account.portfolio.map(AccountsBatch.parseAsset),
+      );
+      accounts.set(account.id, accountData);
+    });
+    return accounts;
+  }
+}

--- a/src/account/AccountsBatch.ts
+++ b/src/account/AccountsBatch.ts
@@ -118,10 +118,9 @@ export default class AccountsBatch {
       throw Error(`Invalid currency ${currencyId}.`);
     }
 
-    const notional =
-      assetType === AssetType.fCash
-        ? TypedBigNumber.from(asset.notional, BigNumberType.InternalUnderlying, currency.underlyingSymbol)
-        : TypedBigNumber.from(asset.notional, BigNumberType.LiquidityToken, currency.symbol);
+    const notional = assetType === AssetType.fCash
+      ? TypedBigNumber.from(asset.notional, BigNumberType.InternalUnderlying, currency.underlyingSymbol)
+      : TypedBigNumber.from(asset.notional, BigNumberType.LiquidityToken, currency.symbol);
 
     const hasMatured = maturity < getNowSeconds();
     const settlementDate = Number(asset.settlementDate);

--- a/src/account/index.ts
+++ b/src/account/index.ts
@@ -1,8 +1,9 @@
 import Account from './Account';
 import AccountData from './AccountData';
+import AccountsBatch from './AccountsBatch';
 import AssetSummary from './AssetSummary';
 import BalanceSummary from './BalanceSummary';
 
 export {
-  Account, AssetSummary, BalanceSummary, AccountData,
+  Account, AssetSummary, BalanceSummary, AccountData, AccountsBatch,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,9 @@ import Notional from './Notional';
 import TypedBigNumber, {BigNumberType} from './libs/TypedBigNumber';
 import {SystemEvents} from './system/System';
 import {AccountEvents} from './account/AccountRefresh';
+import {AccountData} from './account';
 
 export default Notional;
 export {
-  TypedBigNumber,
-  BigNumberType,
-  SystemEvents,
-  AccountEvents,
+  TypedBigNumber, BigNumberType, SystemEvents, AccountEvents, AccountData,
 };

--- a/src/system/System.ts
+++ b/src/system/System.ts
@@ -256,6 +256,14 @@ export default class System {
         this.eventEmitter,
         refreshIntervalMS,
       );
+      // This will fetch the NOTE price via CoinGecko
+      this.ethRateProviders.set(NOTE_CURRENCY_ID, new NoteETHRateProvider(
+        undefined,
+        {
+          notePriceRefreshIntervalMS: refreshConfigurationDataIntervalMs!,
+          eventEmitter: this.eventEmitter,
+        },
+      ));
     } else {
       this.dataSource = new Cache(
         chainId,
@@ -273,8 +281,6 @@ export default class System {
         this.parseQueryResult(result);
       }, refreshConfigurationDataIntervalMs);
     }
-
-    this.ethRateProviders.set(NOTE_CURRENCY_ID, new NoteETHRateProvider());
   }
 
   public destroy() {
@@ -460,6 +466,10 @@ export default class System {
     const underlyingDecimalPlaces = this.assetRate.get(currencyId)?.underlyingDecimalPlaces;
     const assetRate = this.dataSource.assetRateData.get(currencyId);
     return {underlyingDecimalPlaces, assetRate};
+  }
+
+  public getETHProvider(currencyId: number) {
+    return this.ethRateProviders.get(currencyId);
   }
 
   public getETHRate(currencyId: number) {

--- a/src/system/System.ts
+++ b/src/system/System.ts
@@ -574,7 +574,7 @@ export default class System {
       },
     );
     if (settlementRateResponse.settlementRates.length === 0) {
-      throw new Error(`Asset rate data for ${currencyId} is not found`);
+      throw new Error(`Settlement rate data for ${currencyId} with maturity ${maturity} is not found`);
     }
 
     const settlementRate = settlementRateResponse.settlementRates[0];

--- a/src/system/System.ts
+++ b/src/system/System.ts
@@ -1,18 +1,9 @@
-import {gql} from '@apollo/client/core';
-import {BigNumber, Contract, ethers} from 'ethers';
-import {clearInterval} from 'timers';
+import { gql } from '@apollo/client/core';
+import { BigNumber, Contract, ethers } from 'ethers';
+import { clearInterval } from 'timers';
 import EventEmitter from 'eventemitter3';
-import {
-  Asset,
-  AssetRate,
-  AssetType,
-  Currency,
-  EthRate,
-  nToken,
-  SettlementMarket,
-  TokenType,
-} from '../libs/types';
-import {getNowSeconds} from '../libs/utils';
+import { Asset, AssetRate, AssetType, Currency, EthRate, nToken, SettlementMarket, TokenType } from '../libs/types';
+import { getNowSeconds } from '../libs/utils';
 import {
   DEFAULT_CONFIGURATION_REFRESH_INTERVAL,
   RATE_PRECISION,
@@ -20,16 +11,16 @@ import {
   DEFAULT_DATA_REFRESH_INTERVAL,
 } from '../config/constants';
 
-import {IAggregator} from '../typechain/IAggregator';
-import {AssetRateAggregator} from '../typechain/AssetRateAggregator';
-import {NTokenERC20} from '../typechain/NTokenERC20';
-import {Notional as NotionalProxy} from '../typechain/Notional';
-import {ERC20} from '../typechain/ERC20';
+import { IAggregator } from '../typechain/IAggregator';
+import { AssetRateAggregator } from '../typechain/AssetRateAggregator';
+import { NTokenERC20 } from '../typechain/NTokenERC20';
+import { Notional as NotionalProxy } from '../typechain/Notional';
+import { ERC20 } from '../typechain/ERC20';
 import GraphClient from '../GraphClient';
-import {Market, CashGroup} from '.';
-import TypedBigNumber, {BigNumberType} from '../libs/TypedBigNumber';
+import { Market, CashGroup } from '.';
+import TypedBigNumber, { BigNumberType } from '../libs/TypedBigNumber';
 import NoteETHRateProvider from './NoteETHRateProvider';
-import {DataSource, DataSourceType} from './datasource';
+import { DataSource, DataSourceType } from './datasource';
 import Blockchain from './datasource/Blockchain';
 import Cache from './datasource/Cache';
 
@@ -49,6 +40,52 @@ export enum SystemEvents {
   BLOCK_SUPPLY_RATE_UPDATE = 'BLOCK_SUPPLY_RATE_UPDATE',
   ETH_RATE_UPDATE = 'ETH_RATE_UPDATE',
   NOTE_PRICE_UPDATE = 'NOTE_PRICE_UPDATE',
+}
+
+const settlementMarketsQuery = gql`
+  getMarketsAt($currencyId: String!, settlementDate: Int!){
+    markets(where { currency: $currencyId, settlementDate: $settlementDate }) {
+      id
+      maturity
+      totalfCash
+      totalAssetCash
+      totalLiquidity
+    }
+  }
+`;
+
+interface SettlementMarketsQueryResponse {
+  markets: {
+    id: string;
+    maturity: number;
+    totalfCash: string;
+    totalAssetCash: string;
+    totalLiquidity: string;
+  }[];
+}
+
+const settlementRateQuery = gql`
+  getSettlementRate($currencyId: String!, $maturity: Int!){
+    settlementRates(where {maturity: $maturity, currency: $currencyId}) {
+      id
+      assetExchangeRate {
+        id
+      }
+      maturity
+      rate
+    }
+  }
+`;
+
+interface SettlementRateQueryResponse {
+  settlementRates: {
+    id: string;
+    assetExchangeRate: {
+      id: string;
+    } | null;
+    maturity: number;
+    rate: string;
+  }[];
 }
 
 const systemConfigurationQuery = gql`
@@ -148,7 +185,7 @@ interface SystemQueryResult {
 }
 
 interface IETHRateProvider {
-  getETHRate(): {ethRateConfig: EthRate, ethRate: BigNumber};
+  getETHRate(): { ethRateConfig: EthRate; ethRate: BigNumber };
 }
 
 interface INTokenAssetCashPVProvider {
@@ -232,6 +269,8 @@ export default class System {
         this.eventEmitter,
         refreshIntervalMS,
       );
+    } else {
+      this.dataSource = new Cache(chainId, this.cashGroups, this.eventEmitter, refreshIntervalMS);
     }
 
     this.dataRefreshInterval = this.dataSource.startRefresh();
@@ -426,7 +465,7 @@ export default class System {
   public getAssetRate(currencyId: number) {
     const underlyingDecimalPlaces = this.assetRate.get(currencyId)?.underlyingDecimalPlaces;
     const assetRate = this.dataSource.assetRateData.get(currencyId);
-    return {underlyingDecimalPlaces, assetRate};
+    return { underlyingDecimalPlaces, assetRate };
   }
 
   public getETHProvider(currencyId: number) {
@@ -440,7 +479,7 @@ export default class System {
     }
     const ethRateConfig = this.ethRates.get(currencyId);
     const ethRate = this.dataSource.ethRateData.get(currencyId);
-    return {ethRateConfig, ethRate};
+    return { ethRateConfig, ethRate };
   }
 
   public getNTokenAssetCashPV(currencyId: number) {
@@ -460,7 +499,7 @@ export default class System {
     const liquidityTokens = this.dataSource.nTokenLiquidityTokens.get(currencyId);
     const fCash = this.dataSource.nTokenfCash.get(currencyId);
 
-    return {cashBalance, liquidityTokens, fCash};
+    return { cashBalance, liquidityTokens, fCash };
   }
 
   public getNTokenIncentiveFactors(currencyId: number) {
@@ -528,8 +567,18 @@ export default class System {
       return this.settlementRates.get(key)!;
     }
 
-    const settlementRate = await this.notionalProxy.getSettlementRate(currencyId, maturity);
-    if (settlementRate.underlyingDecimals.isZero()) {
+    const settlementRateResponse = await this.graphClient.queryOrThrow<SettlementRateQueryResponse>(
+      settlementRateQuery,
+      {
+        variables: { currencyId, maturity },
+      },
+    );
+    if (settlementRateResponse.settlementRates.length === 0) {
+      throw new Error(`Asset rate data for ${currencyId} is not found`);
+    }
+
+    const settlementRate = settlementRateResponse.settlementRates[0];
+    if (!settlementRate.assetExchangeRate) {
       // This means the rate is not set and we get the current asset rate, don't set the rate here
       // will refetch on the next call.
       const assetRate = this.dataSource.assetRateData.get(currencyId);
@@ -539,8 +588,9 @@ export default class System {
       return assetRate;
     }
 
-    this.settlementRates.set(key, settlementRate.rate);
-    return settlementRate.rate;
+    const rate = BigNumber.from(settlementRate.rate);
+    this.settlementRates.set(key, rate);
+    return rate;
   }
 
   private async getSettlementMarket(currencyId: number, maturity: number, settlementDate: number) {
@@ -549,9 +599,14 @@ export default class System {
       return this.settlementMarkets.get(key)!;
     }
 
-    const settlementMarkets = await this.notionalProxy.getActiveMarketsAtBlockTime(currencyId, settlementDate);
-    settlementMarkets.forEach((m) => {
-      const k = `${currencyId}:${settlementDate}:${m.maturity.toNumber()}`;
+    const settlementMarkets = await this.graphClient.queryOrThrow<SettlementMarketsQueryResponse>(
+      settlementMarketsQuery,
+      {
+        variables: { currencyId, settlementDate },
+      },
+    );
+    settlementMarkets.markets.forEach((m) => {
+      const k = `${currencyId}:${settlementDate}:${m.maturity}`;
       const currency = this.getCurrencyById(currencyId);
       const underlyingSymbol = this.getUnderlyingSymbol(currencyId);
       this.settlementMarkets.set(k, {

--- a/src/system/System.ts
+++ b/src/system/System.ts
@@ -263,8 +263,6 @@ export default class System {
         this.eventEmitter,
         refreshIntervalMS,
       );
-    } else {
-      this.dataSource = new Cache(chainId, this.cashGroups, this.eventEmitter, refreshIntervalMS);
     }
 
     this.dataRefreshInterval = this.dataSource.startRefresh();

--- a/src/system/System.ts
+++ b/src/system/System.ts
@@ -1,9 +1,11 @@
-import { gql } from '@apollo/client/core';
-import { BigNumber, Contract, ethers } from 'ethers';
-import { clearInterval } from 'timers';
+import {gql} from '@apollo/client/core';
+import {BigNumber, Contract, ethers} from 'ethers';
+import {clearInterval} from 'timers';
 import EventEmitter from 'eventemitter3';
-import { Asset, AssetRate, AssetType, Currency, EthRate, nToken, SettlementMarket, TokenType } from '../libs/types';
-import { getNowSeconds } from '../libs/utils';
+import {
+  Asset, AssetRate, AssetType, Currency, EthRate, nToken, SettlementMarket, TokenType,
+} from '../libs/types';
+import {getNowSeconds} from '../libs/utils';
 import {
   DEFAULT_CONFIGURATION_REFRESH_INTERVAL,
   RATE_PRECISION,
@@ -11,16 +13,16 @@ import {
   DEFAULT_DATA_REFRESH_INTERVAL,
 } from '../config/constants';
 
-import { IAggregator } from '../typechain/IAggregator';
-import { AssetRateAggregator } from '../typechain/AssetRateAggregator';
-import { NTokenERC20 } from '../typechain/NTokenERC20';
-import { Notional as NotionalProxy } from '../typechain/Notional';
-import { ERC20 } from '../typechain/ERC20';
+import {IAggregator} from '../typechain/IAggregator';
+import {AssetRateAggregator} from '../typechain/AssetRateAggregator';
+import {NTokenERC20} from '../typechain/NTokenERC20';
+import {Notional as NotionalProxy} from '../typechain/Notional';
+import {ERC20} from '../typechain/ERC20';
 import GraphClient from '../GraphClient';
-import { Market, CashGroup } from '.';
-import TypedBigNumber, { BigNumberType } from '../libs/TypedBigNumber';
+import {Market, CashGroup} from '.';
+import TypedBigNumber, {BigNumberType} from '../libs/TypedBigNumber';
 import NoteETHRateProvider from './NoteETHRateProvider';
-import { DataSource, DataSourceType } from './datasource';
+import {DataSource, DataSourceType} from './datasource';
 import Blockchain from './datasource/Blockchain';
 import Cache from './datasource/Cache';
 
@@ -43,8 +45,8 @@ export enum SystemEvents {
 }
 
 const settlementMarketsQuery = gql`
-  getMarketsAt($currencyId: String!, settlementDate: Int!){
-    markets(where { currency: $currencyId, settlementDate: $settlementDate }) {
+  query getMarketsAt($currencyId: String!, $settlementDate: Int!) {
+    markets(where: { currency: $currencyId, settlementDate: $settlementDate }) {
       id
       maturity
       totalfCash
@@ -65,8 +67,8 @@ interface SettlementMarketsQueryResponse {
 }
 
 const settlementRateQuery = gql`
-  getSettlementRate($currencyId: String!, $maturity: Int!){
-    settlementRates(where {maturity: $maturity, currency: $currencyId}) {
+  query getSettlementRate($currencyId: String!, $maturity: Int!) {
+    settlementRates(where: { maturity: $maturity, currency: $currencyId }) {
       id
       assetExchangeRate {
         id
@@ -185,7 +187,7 @@ interface SystemQueryResult {
 }
 
 interface IETHRateProvider {
-  getETHRate(): { ethRateConfig: EthRate; ethRate: BigNumber };
+  getETHRate(): {ethRateConfig: EthRate; ethRate: BigNumber};
 }
 
 interface INTokenAssetCashPVProvider {
@@ -465,7 +467,7 @@ export default class System {
   public getAssetRate(currencyId: number) {
     const underlyingDecimalPlaces = this.assetRate.get(currencyId)?.underlyingDecimalPlaces;
     const assetRate = this.dataSource.assetRateData.get(currencyId);
-    return { underlyingDecimalPlaces, assetRate };
+    return {underlyingDecimalPlaces, assetRate};
   }
 
   public getETHProvider(currencyId: number) {
@@ -479,7 +481,7 @@ export default class System {
     }
     const ethRateConfig = this.ethRates.get(currencyId);
     const ethRate = this.dataSource.ethRateData.get(currencyId);
-    return { ethRateConfig, ethRate };
+    return {ethRateConfig, ethRate};
   }
 
   public getNTokenAssetCashPV(currencyId: number) {
@@ -499,7 +501,7 @@ export default class System {
     const liquidityTokens = this.dataSource.nTokenLiquidityTokens.get(currencyId);
     const fCash = this.dataSource.nTokenfCash.get(currencyId);
 
-    return { cashBalance, liquidityTokens, fCash };
+    return {cashBalance, liquidityTokens, fCash};
   }
 
   public getNTokenIncentiveFactors(currencyId: number) {
@@ -570,7 +572,7 @@ export default class System {
     const settlementRateResponse = await this.graphClient.queryOrThrow<SettlementRateQueryResponse>(
       settlementRateQuery,
       {
-        variables: { currencyId, maturity },
+        variables: {currencyId, maturity},
       },
     );
     if (settlementRateResponse.settlementRates.length === 0) {
@@ -602,7 +604,7 @@ export default class System {
     const settlementMarkets = await this.graphClient.queryOrThrow<SettlementMarketsQueryResponse>(
       settlementMarketsQuery,
       {
-        variables: { currencyId, settlementDate },
+        variables: {currencyId, settlementDate},
       },
     );
     settlementMarkets.markets.forEach((m) => {

--- a/src/system/datasource/Blockchain.ts
+++ b/src/system/datasource/Blockchain.ts
@@ -125,8 +125,8 @@ export default class Blockchain extends DataSource {
       promises.push(
         this.notionalProxy.getNTokenPortfolio(n.contract.address).then((value) => {
           const {liquidityTokens, netfCashAssets} = value;
-          this.nTokenLiquidityTokens.set(k, AccountData.parsePortfolio(liquidityTokens));
-          this.nTokenfCash.set(k, AccountData.parsePortfolio(netfCashAssets));
+          this.nTokenLiquidityTokens.set(k, AccountData.parsePortfolioFromBlockchain(liquidityTokens));
+          this.nTokenfCash.set(k, AccountData.parsePortfolioFromBlockchain(netfCashAssets));
           this.eventEmitter.emit(SystemEvents.NTOKEN_ACCOUNT_UPDATE, k);
         }),
       );

--- a/tests/unit/AccountData.test.ts
+++ b/tests/unit/AccountData.test.ts
@@ -164,13 +164,15 @@ describe('Account Data', () => {
       }],
     };
 
-    AccountData.load(accountResult).then((a) => {
-      expect(a.cashBalance(2)?.toString()).toEqual('50000.0');
-      expect(a.portfolio.length).toEqual(0);
-      done();
-    }).catch(() => {
-      done();
-    });
+    AccountData.loadFromBlockchain(accountResult)
+      .then((a) => {
+        expect(a.cashBalance(2)?.toString()).toEqual('50000.0');
+        expect(a.portfolio.length).toEqual(0);
+        done();
+      })
+      .catch(() => {
+        done();
+      });
   });
 
   describe('loan to value ratio', () => {


### PR DESCRIPTION
Changed these things to fetch accounts in batch
- System.ts
  - Query data from subgraph for `getSettlementMarket` and `getSettlementRate` methods instead of blockchain
- Added new static class for fetching accounts in batch through subgraph
- Slightly refactored AccountData to accomodate hydrating from blockchain data + subgraph data (new loadFromBlockchain method)

Some linter changes along the way