### PR TITLE
Feature/fix accounts batch

### DIFF
--- a/src/account/AccountGraphLoader.ts
+++ b/src/account/AccountGraphLoader.ts
@@ -158,10 +158,9 @@ export default class AccountGraphLoader {
       throw Error(`Invalid currency ${currencyId}.`);
     }
 
-    const notional =
-      assetType === AssetType.fCash
-        ? TypedBigNumber.from(asset.notional, BigNumberType.InternalUnderlying, currency.underlyingSymbol)
-        : TypedBigNumber.from(asset.notional, BigNumberType.LiquidityToken, currency.symbol);
+    const notional = assetType === AssetType.fCash
+      ? TypedBigNumber.from(asset.notional, BigNumberType.InternalUnderlying, currency.underlyingSymbol)
+      : TypedBigNumber.from(asset.notional, BigNumberType.LiquidityToken, currency.symbol);
 
     const hasMatured = maturity < getNowSeconds();
     const settlementDate = Number(asset.settlementDate);
@@ -186,7 +185,7 @@ export default class AccountGraphLoader {
    * @returns
    */
   public static async loadBatch(graphClient: GraphClient, pageSize: number, pageNumber: number) {
-    const response = await graphClient.queryOrThrow<AccountsQueryResponse>(accountsQuery, { pageSize, pageNumber });
+    const response = await graphClient.queryOrThrow<AccountsQueryResponse>(accountsQuery, {pageSize, pageNumber});
     const accounts = new Map<string, AccountData>();
     // eslint-disable-next-line no-restricted-syntax
     for (const account of response.accounts) {
@@ -213,7 +212,7 @@ export default class AccountGraphLoader {
   public static async getBalanceSummary(address: string, accountData: AccountData, graphClient: GraphClient) {
     const balanceHistory = await BalanceSummary.fetchBalanceHistory(address, graphClient);
     const balanceSummary = BalanceSummary.build(accountData, balanceHistory);
-    return { balanceHistory, balanceSummary };
+    return {balanceHistory, balanceSummary};
   }
 
   /**
@@ -222,7 +221,7 @@ export default class AccountGraphLoader {
   public static async getAssetSummary(address: string, accountData: AccountData, graphClient: GraphClient) {
     const tradeHistory = await AssetSummary.fetchTradeHistory(address, graphClient);
     const assetSummary = AssetSummary.build(accountData, tradeHistory);
-    return { tradeHistory, assetSummary };
+    return {tradeHistory, assetSummary};
   }
 
   /**
@@ -233,7 +232,7 @@ export default class AccountGraphLoader {
    */
   public static async load(graphClient: GraphClient, address: string) {
     const lowerCaseAddress = address.toLowerCase(); // Account id in subgraph is in lower case.
-    const { account } = await graphClient.queryOrThrow<AccountQueryResponse>(accountQuery, { id: lowerCaseAddress });
+    const {account} = await graphClient.queryOrThrow<AccountQueryResponse>(accountQuery, {id: lowerCaseAddress});
 
     const balances = account.balances.map(AccountGraphLoader.parseBalance);
     const portfolio = account.portfolio.map(AccountGraphLoader.parseAsset);

--- a/src/account/AccountGraphLoader.ts
+++ b/src/account/AccountGraphLoader.ts
@@ -158,9 +158,10 @@ export default class AccountGraphLoader {
       throw Error(`Invalid currency ${currencyId}.`);
     }
 
-    const notional = assetType === AssetType.fCash
-      ? TypedBigNumber.from(asset.notional, BigNumberType.InternalUnderlying, currency.underlyingSymbol)
-      : TypedBigNumber.from(asset.notional, BigNumberType.LiquidityToken, currency.symbol);
+    const notional =
+      assetType === AssetType.fCash
+        ? TypedBigNumber.from(asset.notional, BigNumberType.InternalUnderlying, currency.underlyingSymbol)
+        : TypedBigNumber.from(asset.notional, BigNumberType.LiquidityToken, currency.symbol);
 
     const hasMatured = maturity < getNowSeconds();
     const settlementDate = Number(asset.settlementDate);
@@ -185,11 +186,13 @@ export default class AccountGraphLoader {
    * @returns
    */
   public static async loadBatch(graphClient: GraphClient, pageSize: number, pageNumber: number) {
-    const response = await graphClient.queryOrThrow<AccountsQueryResponse>(accountsQuery, {pageSize, pageNumber});
+    const response = await graphClient.queryOrThrow<AccountsQueryResponse>(accountsQuery, { pageSize, pageNumber });
     const accounts = new Map<string, AccountData>();
-    response.accounts.forEach(async (account) => {
-      // Ideally, all settlement rates and markets that may be concerned by these accounts would be pre-loaded
-      // and these Promises could be avoided. Optimization will be needed once there are many settled markets.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const account of response.accounts) {
+      // It is actually more optimal to execute these promises in series.
+      // Reason is that async network calls inside these load calls are cached.
+      // Subsequent load calls can then leverage previous results.
       // eslint-disable-next-line no-await-in-loop
       const accountData = await AccountData.load(
         account.nextSettleTime,
@@ -200,7 +203,7 @@ export default class AccountGraphLoader {
         account.portfolio.map(AccountGraphLoader.parseAsset),
       );
       accounts.set(account.id, accountData);
-    });
+    }
     return accounts;
   }
 
@@ -210,7 +213,7 @@ export default class AccountGraphLoader {
   public static async getBalanceSummary(address: string, accountData: AccountData, graphClient: GraphClient) {
     const balanceHistory = await BalanceSummary.fetchBalanceHistory(address, graphClient);
     const balanceSummary = BalanceSummary.build(accountData, balanceHistory);
-    return {balanceHistory, balanceSummary};
+    return { balanceHistory, balanceSummary };
   }
 
   /**
@@ -219,7 +222,7 @@ export default class AccountGraphLoader {
   public static async getAssetSummary(address: string, accountData: AccountData, graphClient: GraphClient) {
     const tradeHistory = await AssetSummary.fetchTradeHistory(address, graphClient);
     const assetSummary = AssetSummary.build(accountData, tradeHistory);
-    return {tradeHistory, assetSummary};
+    return { tradeHistory, assetSummary };
   }
 
   /**
@@ -230,7 +233,7 @@ export default class AccountGraphLoader {
    */
   public static async load(graphClient: GraphClient, address: string) {
     const lowerCaseAddress = address.toLowerCase(); // Account id in subgraph is in lower case.
-    const {account} = await graphClient.queryOrThrow<AccountQueryResponse>(accountQuery, {id: lowerCaseAddress});
+    const { account } = await graphClient.queryOrThrow<AccountQueryResponse>(accountQuery, { id: lowerCaseAddress });
 
     const balances = account.balances.map(AccountGraphLoader.parseBalance);
     const portfolio = account.portfolio.map(AccountGraphLoader.parseAsset);


### PR DESCRIPTION
- Loaded accounts with assets that are past maturity would trigger an async call to load settled markets.
- Promise from AccountData.load were not awaited properly.
- This would create a race condition where accounts with settled assets wouldn't make it into the accounts map before the Account.load promise resolved.