### PR TITLE
Catch exceptions when batch loading accounts

### DIFF
--- a/src/account/AccountData.ts
+++ b/src/account/AccountData.ts
@@ -206,14 +206,21 @@ export default class AccountData {
 
     // eslint-disable-next-line no-restricted-syntax
     for (const asset of maturedAssets) {
-      // eslint-disable-next-line no-await-in-loop
-      const {assetCash, fCashAsset} = await system.settlePortfolioAsset(asset);
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const {assetCash, fCashAsset} = await system.settlePortfolioAsset(asset);
 
-      // Use private static methods to bypass copy check
-      // eslint-disable-next-line no-underscore-dangle
-      if (fCashAsset) AccountData._updateAsset(portfolio, asset, bitmapCurrencyId);
-      // eslint-disable-next-line no-underscore-dangle
-      AccountData._updateBalance(balances, asset.currencyId, assetCash, undefined, bitmapCurrencyId);
+        // Use private static methods to bypass copy check
+        // eslint-disable-next-line no-underscore-dangle
+        if (fCashAsset) AccountData._updateAsset(portfolio, asset, bitmapCurrencyId);
+        // eslint-disable-next-line no-underscore-dangle
+        AccountData._updateBalance(balances, asset.currencyId, assetCash, undefined, bitmapCurrencyId);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to load matured asset.');
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
     }
 
     return new AccountData(nextSettleTime, hasCashDebt, hasAssetDebt, bitmapCurrencyId, balances, portfolio, false);

--- a/src/account/AccountGraphLoader.ts
+++ b/src/account/AccountGraphLoader.ts
@@ -188,20 +188,15 @@ export default class AccountGraphLoader {
     const response = await graphClient.queryOrThrow<AccountsQueryResponse>(accountsQuery, {pageSize, pageNumber});
     const accounts = new Map<string, AccountData>();
     await Promise.all(response.accounts.map(async (account) => {
-      try {
-        const accountData = await AccountData.load(
-          account.nextSettleTime,
-          account.hasCashDebt,
-          account.hasPortfolioAssetDebt,
-          account.assetBitmapCurrency?.id ? Number(account.assetBitmapCurrency.id) : undefined,
-          account.balances.map(AccountGraphLoader.parseBalance),
-          account.portfolio.map(AccountGraphLoader.parseAsset),
-        );
-        accounts.set(account.id, accountData);
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
-      }
+      const accountData = await AccountData.load(
+        account.nextSettleTime,
+        account.hasCashDebt,
+        account.hasPortfolioAssetDebt,
+        account.assetBitmapCurrency?.id ? Number(account.assetBitmapCurrency.id) : undefined,
+        account.balances.map(AccountGraphLoader.parseBalance),
+        account.portfolio.map(AccountGraphLoader.parseAsset),
+      );
+      accounts.set(account.id, accountData);
     }));
     return accounts;
   }

--- a/src/account/AccountGraphLoader.ts
+++ b/src/account/AccountGraphLoader.ts
@@ -188,15 +188,20 @@ export default class AccountGraphLoader {
     const response = await graphClient.queryOrThrow<AccountsQueryResponse>(accountsQuery, {pageSize, pageNumber});
     const accounts = new Map<string, AccountData>();
     await Promise.all(response.accounts.map(async (account) => {
-      const accountData = await AccountData.load(
-        account.nextSettleTime,
-        account.hasCashDebt,
-        account.hasPortfolioAssetDebt,
-        account.assetBitmapCurrency?.id ? Number(account.assetBitmapCurrency.id) : undefined,
-        account.balances.map(AccountGraphLoader.parseBalance),
-        account.portfolio.map(AccountGraphLoader.parseAsset),
-      );
-      return accounts.set(account.id, accountData);
+      try {
+        const accountData = await AccountData.load(
+          account.nextSettleTime,
+          account.hasCashDebt,
+          account.hasPortfolioAssetDebt,
+          account.assetBitmapCurrency?.id ? Number(account.assetBitmapCurrency.id) : undefined,
+          account.balances.map(AccountGraphLoader.parseBalance),
+          account.portfolio.map(AccountGraphLoader.parseAsset),
+        );
+        accounts.set(account.id, accountData);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
     }));
     return accounts;
   }


### PR DESCRIPTION
While testing on Kovan, I realized it's possible some accounts have negative net cash change (`netCashChange.isNegative()`), which in that case would throw when calling `AccountData. _updateBalance`

I simply wrapped `AccountData.load` call in a try catch statement and made sure to at least log error through `console.error`