### PR TITLE
adding method to destroy notional

### DIFF
--- a/src/Notional.ts
+++ b/src/Notional.ts
@@ -175,6 +175,10 @@ export default class Notional extends TransactionBuilder {
     return new Notional(contracts.note, graphClient, governance, system, provider, contracts);
   }
 
+  public destroy() {
+    this.system.destroy()
+  }
+
   public async getAccount(address: string | Signer) {
     return await Account.load(
       address,


### PR DESCRIPTION
@mgnsharon Will this work? Note that Accounts need to be destroyed separately as well, they have their own version of this that is called in fetchAndSetAccount in sagas-wallet.js